### PR TITLE
Add support for osm2pgsql-gen

### DIFF
--- a/osm2pgsql/scripts/entrypoint.sh
+++ b/osm2pgsql/scripts/entrypoint.sh
@@ -1,18 +1,21 @@
 #!/bin/sh
 
 # Check the first argument for multiple conditions
-if [ "$1" = "replication" ] || [ "$1" = "osm2pgsql-replication" ]; then
-    # If the first argument is "replication" or "osm2pgsql-replication", shift it off
+case "$1" in
+  osm2pgsql*)
+    # If the first argument is beginning with "osm2pgsql",
+    # call it verbatim
+    exec "$@"
+    ;;
+  replication)
+    # If the first argument is "replication", shift it off
     # and pass the remaining arguments to osm2pgsql-replication
     shift
     exec osm2pgsql-replication "$@"
-elif [ "$1" = "osm2pgsql" ]; then
-    # If the first argument is "osm2pgsql", shift it off
-    # and pass the remaining arguments to osm2pgsql
-    shift
-    exec osm2pgsql "$@"
-else
+    ;;
+  *)
     # If the first argument is anything else or not provided,
     # pass all arguments to osm2pgsql, assuming the user wants to use osm2pgsql directly
     exec osm2pgsql "$@"
-fi
+    ;;
+esac


### PR DESCRIPTION
To use `osm2pgsql-gen` a slightly different `entrypoint.sh` logic is needed.

(BTW: I need it for a project started at the same OSM Hack weekend)